### PR TITLE
setattr/getattr

### DIFF
--- a/s2d2/sentinel2_band.py
+++ b/s2d2/sentinel2_band.py
@@ -57,12 +57,12 @@ class Sentinel2Band():
                                         outline=det_num, fill=det_num)
             msk = np.array(msk)
             det_msk = np.maximum(det_msk, msk)
-        setattr(self, 'detector', det_msk)
+        self.detector = det_msk
 
     def read_band(self,
                   path: Path,
                   fname: Optional[str]):
-        #todo: what to do with full integration...
+        # todo: what to do with full integration...
         img_path = os.path.join(path, fname)
         img = gdal.Open(img_path)
         assert img is not None, ('could not open dataset ' + fname)
@@ -71,14 +71,13 @@ class Sentinel2Band():
         no_dat = img.GetRasterBand(1).GetNoDataValue()
         np.putmask(band, band == no_dat, 0)
 
-        setattr(self, 'digitalnumbers', band)
-        setattr(self, 'unit', 'DN')
+        self.digitalnumbers = band
+        self.unit = 'DN'
 
     def dn_to_toa(self):
-        if getattr(self, 'unit') == 'TOA': return
-        assert(getattr(self, 'unit') == 'DN'), 'input should be digital numbers'
+        if self.unit == 'TOA':
+            return
+        assert (self.unit == 'DN'), 'input should be digital numbers'
 
-        TOA = dn_to_toa(getattr(self, 'digitalnumbers'))
-
-        setattr(self, 'digitalnumbers', TOA)
-        setattr(self, 'unit', 'TOA')
+        self.digitalnumbers = dn_to_toa(self.digitalnumbers)
+        self.unit = 'TOA'

--- a/s2d2/sentinel2_grid.py
+++ b/s2d2/sentinel2_grid.py
@@ -3,6 +3,7 @@ import numpy as np
 from .checking.array import are_two_arrays_equal
 from .checking.mapping import correct_geotransform
 
+
 class Sentinel2Anglegrid:
     def __init__(self) -> None:
         # mapping specifics
@@ -29,13 +30,12 @@ class Sentinel2Anglegrid:
         grid = getattr(self, angle_type)
         if grid is None:
             grid = np.atleast_3d(angles)
-            setattr(self, 'rows', grid.shape[0])
-            setattr(self, 'columns', grid.shape[1])
+            self.rows = grid.shape[0]
+            self.columns = grid.shape[1]
         else:
             grid = np.dstack((grid, angles))
-        setattr(self, 'depth', grid.shape[2])
+        self.depth = grid.shape[2]
         setattr(self, angle_type, grid)
-
 
     def check_consistency(self) -> None:
         are_two_arrays_equal(self.zenith, self.azimuth)
@@ -45,4 +45,3 @@ class Sentinel2Anglegrid:
         assert self.rows == self.zenith.shape[0], 'dimensions are not consistent with data'
         assert self.columns == self.zenith.shape[1], 'dimensions are not consistent with data'
         assert self.depth == self.zenith.shape[2], 'dimensions are not consistent with data'
-


### PR DESCRIPTION
When possible, `self.a = b` is preferred over `setattr(self, 'a', b)` for readability. 